### PR TITLE
dt 要素にアンダーラインを追加

### DIFF
--- a/scss/lib/_content.scss
+++ b/scss/lib/_content.scss
@@ -62,6 +62,7 @@
     }
     dt {
         font-weight: bold;
+        border-bottom: 1px dashed $border;
     }
     table {
         border-collapse: collapse;


### PR DESCRIPTION
タイトル付きリストのタイトル部分にあたる `dt` 要素にアンダーラインを付与します。

過去に制作していた WordPress テーマのデザインの一部を引き継いだものです。