### PR TITLE
サイドバーモジュールの微調整

### DIFF
--- a/scss/lib/_hatena-module.scss
+++ b/scss/lib/_hatena-module.scss
@@ -85,6 +85,11 @@
     .urllist-entry-body {
         margin-top: .3em;
     }
+    .archive-module-hide-button,
+    .archive-module-show-button {
+        font-size: .75rem;
+        margin-right: .125rem;
+    }
 }
 
 /* Search module */

--- a/scss/lib/_hatena-module.scss
+++ b/scss/lib/_hatena-module.scss
@@ -36,6 +36,13 @@
         }
     }
 }
+.hatena-module-body {
+    .archive-module-hide-button,
+    .archive-module-show-button {
+        font-size: .75rem;
+        margin-right: .125rem;
+    }
+}
 
 /* Profile module */
 .hatena-module-profile {
@@ -84,11 +91,6 @@
     }
     .urllist-entry-body {
         margin-top: .3em;
-    }
-    .archive-module-hide-button,
-    .archive-module-show-button {
-        font-size: .75rem;
-        margin-right: .125rem;
     }
 }
 

--- a/scss/lib/_hatena-module.scss
+++ b/scss/lib/_hatena-module.scss
@@ -132,6 +132,7 @@
     }
 }
 
+/* Recent comments module */
 .hatena-module-recent-comments {
     .user-id {
         display: block;

--- a/scss/lib/_hatena-module.scss
+++ b/scss/lib/_hatena-module.scss
@@ -129,3 +129,9 @@
         }
     }
 }
+
+.hatena-module-recent-comments {
+    .user-id {
+        display: block;
+    }
+}


### PR DESCRIPTION
サイドバーモジュールの表示バランスを整えるために、下記の調整を行います。

- アコーディオンボタン (月別アーカイブで年から月に展開する際に使う 🔽 とかの部分) の小型化
- 最近のコメントのユーザー名部分のブロック要素化
  - サイドバー部分は幅が狭く、コメント先の記事名が折り返されることが多いので、いっその事ユーザー名と記事名で別々の行にしてしまおう