### PR TITLE
エントリー周りのスタイルの微調整

### DIFF
--- a/scss/lib/_entry.scss
+++ b/scss/lib/_entry.scss
@@ -6,6 +6,7 @@
     color: $text;
     margin-bottom: 3em;
     box-sizing: border-box;
+    overflow-wrap: break-word;
     padding: $spacing;
     @media #{$mq-lg} {
         padding: $spacing-large;
@@ -88,6 +89,7 @@
 .entry-title {
     margin: 0 0 .3em;
     font-size: 1.5rem;
+    font-weight: 900;
     @media #{$mq-md} {
         font-size: 1.6rem;
     }


### PR DESCRIPTION
より見やすくするために、エントリー周りに下記の調整を行います。

- タイトルの太さをより太く設定 (700 → 900)
- 長い単語の折返しを有効化
  - 主にスマートフォンで閲覧する際に有効的なはず