### PR TITLE
フッターの調整

### DIFF
--- a/scss/lib/_core.scss
+++ b/scss/lib/_core.scss
@@ -63,9 +63,11 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 /**
- * ヘッダーの背景色の設定
+ * ヘッダーの背景色とフッター背景色の設定
  *     ヘッダー画像を設定しない場合の背景色を変更したい場合は、下記セレクタをご利用ください。
+ *     この背景色はフッターも対象です。
  */
-#blog-title-inner {
+#blog-title-inner,
+#footer-inner {
     background-color: $bg-light;
 }

--- a/scss/lib/_layout.scss
+++ b/scss/lib/_layout.scss
@@ -145,6 +145,12 @@
     p {
         margin: .5em auto;
     }
+    a {
+        text-decoration: none;
+        &:hover {
+            text-decoration: underline;
+        }
+    }
     @media #{$mq-sm} {
         @include content-style;
     }


### PR DESCRIPTION
Close: #12 

フッターテキストを見やすくするために、下記の調整を施します。

- リンクがマウスにのせない場合に限り、下線を削除するように変更
- フッターの背景色をヘッダーの背景色と同じように変更
  - モデルである Twenty Fifteen も同じようにフッターに明るい背景色があったため、その追従です