### PR TITLE
エントリー周りの余白を調整

### DIFF
--- a/scss/lib/_entry.scss
+++ b/scss/lib/_entry.scss
@@ -7,16 +7,19 @@
     margin-bottom: 3em;
     box-sizing: border-box;
     overflow-wrap: break-word;
-    padding: $spacing;
-    @media #{$mq-lg} {
-        padding: $spacing-large;
-    }
 }
 
 @mixin entry-heading {
     background-color: $bg-entry;
     border-bottom: 2px solid $border;
     padding: .25em .5em;
+}
+
+@mixin entry-spacing {
+    padding: $spacing;
+    @media #{$mq-lg} {
+        padding: $spacing-large;
+    }
 }
 
 @mixin entry-button {
@@ -70,8 +73,7 @@
     position: relative;
 }
 .entry-header {
-    padding-bottom: 1em;
-    margin-bottom: 2em;
+    @include entry-spacing;
     border-bottom: 1px solid $border;
     position: relative;
 }
@@ -108,12 +110,16 @@
 /* 「編集する」ボタン */
 .entry-header-menu {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: $spacing;
+    right: $spacing;
     a {
         @include hatena-button;
         font-size: .85rem;
     }
+}
+
+.entry-content {
+    @include entry-spacing;
 }
 
 /* 続きを読む */
@@ -123,6 +129,7 @@
 
 /* 記事下 */
 .entry-footer {
+    @include entry-spacing;
     .social-buttons {
         margin-bottom: 1em;
     }

--- a/scss/lib/_entry.scss
+++ b/scss/lib/_entry.scss
@@ -118,6 +118,7 @@
     }
 }
 
+/* 記事の内容 */
 .entry-content {
     @include entry-spacing;
 }


### PR DESCRIPTION
モデルとなった Twenty Fifteen では、フッターだけ背景色が違う仕様となっています。

はてなブログでは、カテゴリー等の情報がヘッダーに集中していることと、ヘッダーが別背景色になっていないことから、ヘッダーと内容、フッターにそれぞれ余白を付与し、ヘッダー下のボーダーを投稿領域全体に広げるようにします。